### PR TITLE
Change imgur links to filegarden links

### DIFF
--- a/data.js
+++ b/data.js
@@ -3,8 +3,8 @@
     {
       id: "0",
       name: "Medusa",
-      back: "https://i.imgur.com/cfMnfuH.png",
-      minis: ["https://i.imgur.com/tPXKCCD.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/medusa-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/medusa-mini.png"],
       desc: "Medusa is a ranged character, supported by 3 harpy melee sidekicks. She can deal massive combat damage, do direct (unavoidable) damage and force her opponent to discard cards. Without mentioning the harpies' resurrection... She's traditionally considered as one of the strongest fighters released.",
       ability: "At the start of her turn, she may deal 1 damage to an opposing fighter in her zone.",
       guides: [{
@@ -21,8 +21,8 @@
     {
       id: "1",
       name: "Sinbad",
-      back: "https://i.imgur.com/ZXplzL9.png",
-      minis: ["https://i.imgur.com/6Mh7GdG.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/sinbad-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/sinbad-mini.png"],
       desc: "Sinbad is a melee fighter, supported by a porter sidekick. Sinbad grows in power as he gains experience on each of his voyages. His <i>Voyage</i> cards (6 in total) get +1 power per other <i>Voyage</i> in his discard pile. He gets also faster: +1 move per <i>Voyage</i> in his discard pile.",
       ability: "When he maneuvers, he may move his fighters +1 space for each <i>Voyage</i> card in his discard pile.",
       guides: [{
@@ -39,8 +39,8 @@
     {
       id: "2",
       name: "Alice",
-      back: "https://i.imgur.com/IPFwBck.png",
-      minis: ["https://i.imgur.com/NHgsEcs.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/alice-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/alice-mini.png"],
       desc: "Alice is a melee fighter with a Jabberwock sidekick. She has two stances: <i>Big</i>, which increases the value of her attacks and <i>Small</i>, which increases the value of her defense. She can switch from one to the other with card effects.",
       ability: "Player chooses if Alice starts the game <i>Big</i> or <i>Small</i>. When Alice is <i>Big</i>, she adds 2 to the value of her attack cards. When she's <i>Small</i>, she adds 1 to the value of her defense cards.",
       guides: [{
@@ -57,8 +57,8 @@
     {
       id: "3",
       name: "King Arthur",
-      back: "https://i.imgur.com/V4L5MpH.png",
-      minis: ["https://i.imgur.com/4w59eL1.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/king-arthur-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/king-arthur-mini.png"],
       desc: "King Arthur is a melee fighter, supported by Merlin, a ranged sidekick. King Arthur can <i>Boost</i> his attacks.",
       ability: "When King Arthur attacks, he may <i>Boost</i> that attack. If opponent cancels the effects on the attack card, the <i>Boost</i> card is discarded without effect.",
       guides: [{
@@ -75,8 +75,8 @@
     {
       id: "8",
       name: "Bruce Lee",
-      back: "https://i.imgur.com/bp2TeWi.png",
-      minis: ["https://i.imgur.com/xVIYWQH.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/bruce-lee-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/bruce-lee-mini.png"],
       desc: "Bruce Lee is a solo melee hero, able to attack many times in a single round with the help of his \"Gain 1 action\" cards.",
       ability: "At the end of his turn, he may move 1 space.",
       guides: [{
@@ -93,8 +93,8 @@
     {
       id: "4",
       name: "Robin Hood",
-      back: "https://i.imgur.com/iXqCbsI.png",
-      minis: ["https://i.imgur.com/Y2N49YE.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/robin-hood-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/robin-hood-mini.png"],
       desc: "Robin Hood is a ranged (obviously) fighter, supported by 4 melee outlaw sidekicks. He excels at hit and run.",
       ability: "After an attack, he may move the attacking fighter up to 2 spaces.",
       guides: [{
@@ -109,8 +109,8 @@
     {
       id: "5",
       name: "Bigfoot",
-      back: "https://i.imgur.com/3Ll6ePt.png",
-      minis: ["https://i.imgur.com/QIEJqO4.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/bigfoot-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/bigfoot-mini.png"],
       desc: "Bigfoot is a melee fighter, supported by a Jackalope sidekick. He has large raw damage and can refill his hand quickly. He's traditionally considered one of the strongest fighters released.",
       ability: "At the end of his turn, if there are no opposing fighters in Bigfoot's zone, he may draw 1 card.",
       guides: [{
@@ -125,8 +125,8 @@
     {
       id: "9",
       name: "InGen",
-      back: "https://i.imgur.com/qWqgGXW.png",
-      minis: ["https://i.imgur.com/5IzpjrJ.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ingen-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ingen-mini.png"],
       desc: "Robert Muldoon is a ranged fighter, supported by 3 ranged ingen workers. They can slow their opponent down and damage them by placing traps on the board.",
       ability: "At the start of his turn, he may place a trap in an empty space of his current zone . When an opposing fighter enters a space with a trap, the trap goes off: the fighter immediately stops moving and takes 1 damage. Allies may land and move through traps freely without setting them off.",
       guides: [{
@@ -141,8 +141,8 @@
     {
       id: "10",
       name: "Raptors",
-      back: "https://i.imgur.com/WN0Y2jx.png",
-      minis: ["https://i.imgur.com/nI600tL.png", "https://i.imgur.com/5Fmlq35.png", "https://i.imgur.com/BB9O5Lh.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/raptors-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/raptors-mini-a.png", "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/raptors-mini-b.png", "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/raptors-mini-c.png"],
       desc: "Raptors are three fast melee fighters that are trying to surround their opponent to make their attacks stronger.",
       ability: "<i>Raptors</i> add 1 to the value of their attack cards for each of other <i>Raptors</i> adjacent to the defender.",
       guides: [{
@@ -157,8 +157,8 @@
     {
       id: "15",
       name: "Invisible Man",
-      back: "https://i.imgur.com/sx9QD56.png",
-      minis: ["https://i.imgur.com/5s89pIE.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/invisible-man-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/invisible-man-mini.png"],
       desc: "Invisible Man is a melee fighter who uses fog tokens placed on the board to quickly teleport around and trigger stronger card effects if he or his opponent is standing on one of them.",
       ability: "At the start of the game he places 3 fog tokens in separate spaces in his zone. When he is on a space with a fog token, he adds 1 to the value of his defense cards. He may move between two spaces with fog tokens as if they were adjacent.",
       guides: [{
@@ -175,8 +175,8 @@
     {
       id: "16",
       name: "Jekyll & Hyde",
-      back: "https://i.imgur.com/h2X9eAT.png",
-      minis: ["https://i.imgur.com/zwrKdS0.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/jekyll-hyde-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/jekyll-hyde-mini.png"],
       desc: "Jekyll & Hyde is a melee fighter which uses two stances: <i>Jekyll</i> or <i>Hyde</i>. <i>Hyde</i> can do devastating damage but this also exhausts the fighter in different ways.",
       ability: "He starts the game as Dr. Jekyll. At the start of his turn, he may transform into Dr. <i>Jekyll</i> or Mr. <i>Hyde</i>. When he does a maneuver while being Mr. <i>Hyde</i>, he takes 1 damage.",
       guides: [{
@@ -193,8 +193,8 @@
     {
       id: "17",
       name: "Dracula",
-      back: "https://i.imgur.com/a6wsl2J.png",
-      minis: ["https://i.imgur.com/DaGYWgm.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/dracula-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/dracula-mini.png"],
       desc: "Dracula is a melee fighter, supported by 3 sisters sidekicks. He has different ways to move around, he can boost some of his attacks and also (of course) regain life.",
       ability: "At the start of his turn, he may deal 1 damage to a fighter adjacent to him. If he does, he draws a card.",
       guides: [{
@@ -211,8 +211,8 @@
     {
       id: "18",
       name: "Sherlock Holmes",
-      back: "https://i.imgur.com/5ePCxRL.png",
-      minis: ["https://i.imgur.com/sDUY1ms.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/sherlock-holmes-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/sherlock-holmes-mini.png"],
       desc: "Sherlock is a melee fighter, supported by Dr. Watson, a ranged sidekick. He has multiple ways of looking at the opponent's hand and can trigger powerful effects if he can guess some characteristics of the opponent's cards. He's traditionally considered one of the strongest fighters released when played by a skilled player.",
       ability: "Effects on <i>Holmes</i> and <i>Dr. Watson</i> cards cannot be cancelled by an opponent. Effects on <i>Any</i> cards can still be cancelled.",
       guides: [{
@@ -229,8 +229,8 @@
     {
       id: "11",
       name: "Buffy",
-      back: "https://i.imgur.com/ngYiS9k.png",
-      minis: ["https://i.imgur.com/G3N9SgO.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/buffy-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/buffy-mini.png"],
       desc: "Buffy is a melee fighter, supported by either Giles or Xander sidekick.",
       ability: "Buffy may move through spaces containing opposing fighters. At the start of the game, she can choose Xander or Giles as sidekick and shuffle their 5 cards into her base deck of 25 cards.",
       guides: [{
@@ -245,8 +245,8 @@
     {
       id: "12",
       name: "Willow",
-      back: "https://i.imgur.com/uRyF4qg.png",
-      minis: ["https://i.imgur.com/XhZvjb1.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/willow-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/willow-mini.png"],
       desc: "Willow is a ranged fighter, supported by Tara, a ranged sidekick. When Willow is dealt damage, she turns into Dark Willow who allows some of her cards to have additional powerful effects that often also exhaust her.",
       ability: "When Willow or Tara is dealt damage, Willow becomes Dark Willow. At the end of her turn, if Dark Willow is adjacent to Tara, she becomes Willow.",
       guides: [{
@@ -261,8 +261,8 @@
     {
       id: "13",
       name: "Angel",
-      back: "https://i.imgur.com/6G6c9IC.png",
-      minis: ["https://i.imgur.com/FlNESMz.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/angel-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/angel-mini.png"],
       desc: "Angel is a melee fighter, supported by Faith sidekick.",
       ability: "After Angel or Faith attacks, if you lost the combat, draw 1 card.",
       guides: [{
@@ -277,8 +277,8 @@
     {
       id: "14",
       name: "Spike",
-      back: "https://i.imgur.com/8PyWUM7.png",
-      minis: ["https://i.imgur.com/Yv5xPOK.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/spike-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/spike-mini.png"],
       desc: "Spike is a melee fighter, suported by Drusilla sidekick. They are placing <i>Shadow</i> tokens on the board that are used by their card effects.",
       ability: "At the start of his turn, he may place a <i>Shadow</i> token in any space adjacent to Spike or Drusilla.",
       guides: [{
@@ -293,8 +293,8 @@
     {
       id: "6",
       name: "Little Red Riding Hood",
-      back: "https://i.imgur.com/daad4Se.png",
-      minis: ["https://i.imgur.com/mSlDbbe.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/little-red-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/little-red-mini.png"],
       desc: "Little Red is a melee fighter, supported by a Huntsman sidekick. She features a card-combo mechanism: matching icons on the cards she plays to the one in her \"basket\" (discard pile), triggers potent effects.",
       ability: "Resolve an effect on a card she plays if the symbol next to the effect matches the item in her basket.",
       guides: [{
@@ -309,8 +309,8 @@
     {
       id: "7",
       name: "Beowulf",
-      back: "https://i.imgur.com/SYf2mGv.png",
-      minis: ["https://i.imgur.com/EEroYpp.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/beowulf-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/beowulf-mini.png"],
       desc: "Beowulf is a melee fighter, supported by Wiglaf sidekick. Beowulf uses rage points to increase the effects of his cards. He gets one rage point every time he loses life or from card effects.",
       ability: "Beowulf starts with 1 Rage. When Beowulf is dealt damage, he gains 1 Rage. Beowulf has a maximum of 3 rage.",
       guides: [{
@@ -327,8 +327,8 @@
     {
       id: "23",
       name: "Deadpool",
-      back: "https://i.imgur.com/NL4f6p9.png",
-      minis: ["https://i.imgur.com/TGqsJ7S.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/deadpool-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/deadpool-mini.png"],
       desc: "Deadpool is a joke character, he is to Unmatched what Unglued is to Magic the Gathering.",
       ability: "After attacking, Deadpool recovers 1 health. Also, if his opponent's real name is Logan, all of his attacks are +5.",
       guides: [{
@@ -343,8 +343,8 @@
     {
       id: "19",
       name: "Sun Wukong",
-      back: "https://i.imgur.com/zoT0Fy5.png",
-      minis: ["https://i.imgur.com/5jVlvbU.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/sun-wukong-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/sun-wukong-mini.png"],
       desc: "Sun Wukong is a melee fighter with three <i>Clones</i> as sidekicks. He can take damage to put clones out. All of Sun Wukong’s cards can be used for him or any of his <i>Clones</i>.",
       ability: "At the start of his turn, he may take 1 damage to summon a <i>Clone</i> in an empty space adjacent to him. He does not start with any <i>Clones</i> on the board.",
       guides: [{
@@ -359,8 +359,8 @@
     {
       id: "20",
       name: "Yennenga",
-      back: "https://i.imgur.com/uIAJMUc.png",
-      minis: ["https://i.imgur.com/YIwhJCV.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/yennenga-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/yennenga-mini.png"],
       desc: "Yennenga is a ranged fighter, supported by 2 ranged <i>Archers</i> sidekicks. She has many effects based on after-battle movement. She can redirect damage assigned to her to one of her <i>Archer</i> sidekicks, which she can also resurrect.",
       ability: "If Yennenga would take damage, she may assign any amount of that damage to one or more <i>Archers</i> in her zone instead.",
       guides: [{
@@ -375,8 +375,8 @@
     {
       id: "21",
       name: "Achilles",
-      back: "https://i.imgur.com/6MwabDk.png",
-      minis: ["https://i.imgur.com/SYE7TTm.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/achilles-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/achilles-mini.png"],
       desc: "Achilles is a melee fighter, supported by <i>Patroclus</i> sidekick. If <i>Patroclus</i> is defeated, Achilles becomes much stronger and can draw a card for every battle he wins.",
       ability: "When <i>Patroclus</i> is defeated, he discards 2 random cards. While <i>Patroclus</i> is defeated, he adds +2 to the value of all of his attacks. When he wins a combat, he draws 1 card.",
       guides: [{
@@ -391,8 +391,8 @@
     {
       id: "22",
       name: "Bloody Mary",
-      back: "https://i.imgur.com/mhKXYTS.png",
-      minis: ["https://i.imgur.com/siUSACx.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/bloody-mary-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/bloody-mary-mini.png"],
       desc: "Bloody Mary is a melee fighter who cares about the number 3. If she has 3 cards in her hand at the beginning of her turn, she can get an extra action. Some of her cards are devastating if done as a third action. Since she's in a mirror, she can trigger some attacks with opponent's cards values.",
       ability: "At the start of her turn, if she has exactly 3 cards her hand, she gains 1 action.",
       guides: [{
@@ -407,8 +407,8 @@
     {
       id: "31",
       name: "Ghost Rider",
-      back: "https://i.imgur.com/Gh2EOFW.png",
-      minis: ["https://i.imgur.com/GDD7inp.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ghost-rider-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ghost-rider-mini.png"],
       desc: "Ghost Rider is a melee fighter using <i>Hellfire</i> tokens to increase his cards' effects and roll over his opponent's face, doing them damage by doing so.",
       ability: "Ghost Rider starts the game with 5 <i>Hellfire</i>. When he maneuvers he may spend 1 <i>Hellfire</i>. If he does, he increases his movement to 4 and may move through opposing fighters. Then he deals 1 damage to each opposing fighter he moved through.",
       guides: [{
@@ -423,8 +423,8 @@
     {
       id: "32",
       name: "Luke Cage",
-      back: "https://i.imgur.com/YBEqVnH.png",
-      minis: ["https://i.imgur.com/P1dR6HL.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/luke-cage-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/luke-cage-mini.png"],
       desc: "Luke Cage is a melee fighter, supported by ranged Misty Knight sidekick. In general, from his ability and also card's effects, he is very good at defending.",
       ability: "Luke Cage takes 2 less combat damage from attacks. When defending, Luke Cage wins combat if he takes no damage, even if he didn't play a card.",
       guides: [{
@@ -439,8 +439,8 @@
     {
       id: "33",
       name: "Moon Knight",
-      back: "https://i.imgur.com/angeiSB.png",
-      minis: ["https://i.imgur.com/7quLbl1.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/moon-knight-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/moon-knight-mini.png"],
       desc: "Moon Knight is a melee fighter who switches every turn between his different forms that have different abilities.",
       ability: "As <i>Moon Knight</i>, at the start of your turn, move up to 2 spaces. As <i>Khonshu</i> adds +2 to the value of attack cards. He does not take damage from effects other than combat. As <i>Mr. Knight</i>, adds +1 to all defense values. As <i>all of them</i>: at the end of turn, change to your next identity.",
       guides: [{
@@ -455,8 +455,8 @@
     {
       id: "28",
       name: "Bullseye",
-      back: "https://i.imgur.com/8N16P2Q.png",
-      minis: ["https://i.imgur.com/MFTble1.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/bullseye-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/bullseye-mini.png"],
       desc: "Bullseye is a ranged fighter also able to attack 5 spaces away ignoring zones. A lot of his cards care about having already won a combat during the turn to trigger additional effects or increase values, and he has multiple ways to attack with large numbers.",
       ability: "Bullseye can attack from up to 5 spaces away (ignoring zones). This is in addition to also being able to attack in his zone.",
       guides: [{
@@ -471,8 +471,8 @@
     {
       id: "29",
       name: "Daredevil",
-      back: "https://i.imgur.com/QJnzk2F.png",
-      minis: ["https://i.imgur.com/1YDNloM.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/daredevil-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/daredevil-mini.png"],
       desc: "Daredevil is a melee fighter able to blind boost his cards. He has 22 cards instead of 30, but he can easily re-use cards from his discard pile. His fight style cares about being on the edge (of remaining cards in the deck, of cards in hand...) to get powerful effects.",
       ability: "During combat, if Daredevil has 2 or fewer cards in his hand, he may blind boost his attack or defense.",
       guides: [{
@@ -487,8 +487,8 @@
     {
       id: "30",
       name: "Elektra",
-      back: "https://i.imgur.com/euTPd5T.png",
-      minis: ["https://i.imgur.com/hpD6o6r.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/elektra-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/elektra-mini.png"],
       desc: "Elektra is a melee fighter, supported by 4 <i>The Hand</i> sidekicks. Once knocked down to zero hit points, she resurrects as a more powerful version of herself, triggering special abilities on her cards.",
       ability: "The first time Elektra is defeated, remove her and all <i>The Hand</i> from the board. Next turn, she resurrects: she flips her health dial, shuffles her discard pile into her deck. Place her and all Hand back onto the board with each fighter in a different zone. She now resolves <i>Resurrect</i> effects on her cards.",
       guides: [{
@@ -503,8 +503,8 @@
     {
       id: "26",
       name: "T. Rex",
-      back: "https://i.imgur.com/epE4lou.png",
-      minis: ["https://i.imgur.com/6VtgrRy.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/t-rex-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/t-rex-mini.png"],
       desc: "T. Rex is a large melee fighter able to attack up to 2 spaces away. She has multiple possibilities to boost her cards.",
       ability: "T-Rex is a large fighter: she can attack up to 2 spaces away. At the end of your turn, draw a card.",
       guides: [{
@@ -519,8 +519,8 @@
     {
       id: "27",
       name: "Dr. Sattler",
-      back: "https://i.imgur.com/4V9lFj1.png",
-      minis: ["https://i.imgur.com/wxQEi7U.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/dr-ellie-sattler-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/dr-ellie-sattler-mini.png"],
       desc: "Dr. Sattler is a melee fighter, supported by Dr. Malcolm melee sidekick. They can heal for a huge amount of life. They leverage <i>Insight</i> tokens that they place on the board.",
       ability: "After Dr. Sattler or Dr. Malcolm move, they place an <i>Insight</i> token in their new space. They have 5 <i>Insight</i> tokens. Whenever either of them moves to a new space, place an <i>Insight</i> token in their new space. Those tokens have no effect themselves but some cards interact with them.",
       guides: [{
@@ -535,8 +535,8 @@
     {
       id: "24",
       name: "Houdini",
-      back: "https://i.imgur.com/pQmwZa1.png",
-      minis: ["https://i.imgur.com/KjK1FZE.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/houdini-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/houdini-mini.png"],
       desc: "Houdini and his sidekick Bess are melee characters. When Houdini boosts his maneuver, he can move to any space on the board. Some of his cards have an ability attached to their boost value, which triggers when used as a boost.",
       ability: "When he maneuvers and <i>Boost</i> it, he may teleport in any free space instead of moving. Bess moves as normal.",
       guides: [{
@@ -553,8 +553,8 @@
     {
       id: "25",
       name: "The Genie",
-      back: "https://i.imgur.com/2HvORti.png",
-      minis: ["https://i.imgur.com/pVJ8vc7.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/the-genie-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/the-genie-mini.png"],
       desc: "The Genie is a ranged fighter who deals more damage when adjacent to the opponent. He can draw a lot of cards and discard them to play more actions.",
       ability: "At the start of his turn, he may discard 1 card to gain 1 action.",
       guides: [{
@@ -571,8 +571,8 @@
     {
       id: "34",
       name: "Squirrel Girl",
-      back: "https://i.imgur.com/xWVDOeB.png",
-      minis: ["https://i.imgur.com/kqTUiZI.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/squirrel-girl-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/squirrel-girl-mini.png"],
       desc: "Squirrel Girl is a melee fighter, supported by 8 <i>Squirrels</i> small fighters sidekicks. Small fighters can be stacked up to 4 in a single space, even if there is already a normal fighter on it. They can also move through enemies. She cares about having a lot of squirrels around her or enemies to trigger improved card effects.",
       ability: "At the start of her turn, she summons a squirrel in a space adjacent to her. Squirrels are small fighters.",
       guides: [{
@@ -587,8 +587,8 @@
     {
       id: "35",
       name: "Cloak & Dagger",
-      back: "https://i.imgur.com/fhX2IyN.png",
-      minis: ["https://i.imgur.com/LbR8X8c.png", "https://i.imgur.com/zVypDCK.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/cloak-and-dagger-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/cloak-and-dagger-mini-a.png", "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/cloak-and-dagger-mini-b.png"],
       desc: "Cloak & Dagger are melee fighters that have a lot of interactions: they can bounce an opponent from one to the other, they can balance their life points total between them, heal each other, they can swap their places and more.",
       ability: "After attacking, if <i>Cloak</i> dealt at least 2 combat damage, his opponent discards 1 card. After attacking, if <i>Dagger</i> dealt at least 2 combat damage, gain 1 action.",
       guides: [{
@@ -603,8 +603,8 @@
     {
       id: "36",
       name: "Ms. Marvel",
-      back: "https://i.imgur.com/eoWZcBx.png",
-      minis: ["https://i.imgur.com/N3yfxfL.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ms-marvel-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ms-marvel-mini.png"],
       desc: "Ms Marvel is a melee fighter who cares about the zone(s) she's in and about having a large hand.",
       ability: "At the start of her turn, she may move 1 space. She can attack from up to 2 spaces away, ignoring zones.",
       guides: [{
@@ -619,8 +619,8 @@
     {
       id: "41",
       name: "Black Widow",
-      back: "https://i.imgur.com/AaNJasX.png",
-      minis: ["https://i.imgur.com/rx3Wp4N.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/black-widow-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/black-widow-mini.png"],
       desc: "Black Widow and her Maria Hill sidekick are ranged fighters. She tries to meet her special Missions cards condition to obtain different kind of advantages. She has multiple ways to save her sidekick's life.",
       ability: "Black Widow has special scheme cards called Missions requiring special conditions to be played. Whenever a mission is completed, she gets a new one. She starts the game with a mission in her hand.",
       guides: [{
@@ -635,8 +635,8 @@
     {
       id: "42",
       name: "Black Panther",
-      back: "https://i.imgur.com/MbLx8Zl.png",
-      minis: ["https://i.imgur.com/iWWTw1n.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/black-panther-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/black-panther-mini.png"],
       desc: "Black Panther is a melee fighter and his sidekick Shuri a ranged one. He can steal opponents cards from the top of their deck and use them later to Boost for movement or some of his attacks. He has multiple attacks that can be boosted.",
       ability: "Whenever he Boosts, he draws 1 card. Some of his cards effects lets him store opponents cards in his Vibranium Suit. He can use them to Boost.",
       guides: [{
@@ -651,8 +651,8 @@
     {
       id: "43",
       name: "Winter Soldier",
-      back: "https://i.imgur.com/E6WWMwl.png",
-      minis: ["https://i.imgur.com/Dg6wUHr.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/winter-soldier-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/winter-soldier-mini.png"],
       desc: "Winter Soldier is a ranged fighter. His cards effects cannot be canceled but the drawback is that a lot of them include effects beneficial for his opponent. Those unwanted effects can be mitigated when playing well.",
       ability: "Effects on his cards cannot be canceled.",
       guides: [{
@@ -667,8 +667,8 @@
     {
       id: "44",
       name: "Spider-Man",
-      back: "https://i.imgur.com/SOFN52e.png",
-      minis: ["https://i.imgur.com/lMwcdR7.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/spider-man-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/spider-man-mini.png"],
       desc: "Spider-Man is a melee fighter able to foresee the attacks thrown at him. If player knows well his opponent's deck, it can be devastating. He has multiple cards allowing him to move in any space in his zone.",
       ability: "When an opponent attacks him, before he plays a defense card, they must tell the printed value of their card.",
       guides: [{
@@ -683,8 +683,8 @@
     {
       id: "45",
       name: "She-Hulk",
-      back: "https://i.imgur.com/NDvAqPS.png",
-      minis: ["https://i.imgur.com/gh2QUNl.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/she-hulk-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/she-hulk-mini.png"],
       desc: "She-Hulk is a melee fighter. Her ability to deal direct unconditional damages every turn combined with her incredibly high number of life points makes her very dangerous.",
       ability: "At the start of her turn, she may discard a card to deal damage equal to its Boost value to a fighter in her zone.",
       guides: [{
@@ -699,8 +699,8 @@
     {
       id: "46",
       name: "Doctor Strange",
-      back: "https://i.imgur.com/EyxzU9n.png",
-      minis: ["https://i.imgur.com/aDXz0kU.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/doctor-strange-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/doctor-strange-mini.png"],
       desc: "Doctor Strange and his sidekick Wong are ranged fighters. His ability and heal cards allow him to use his life as a resource to draw cards. His cards are full of tricks like forcing his opponent to randomly change a played card or gamble on his top deck card values to deal more damages (or do none).",
       ability: "After each combat, if he played a card, he may deal 1 damage to himself. If he does, he puts that card on the bottom of his deck and draws 1 card.",
       guides: [{
@@ -715,8 +715,8 @@
     {
       id: "37",
       name: "Nikola Tesla",
-      back: "https://i.imgur.com/KVDmJwG.png",
-      minis: ["https://i.imgur.com/doWQfAu.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/nikola-tesla-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/nikola-tesla-mini.png"],
       desc: "Nikola Tesla is a ranged fighter juggling with the charges of his two coils to get additional bonuses and interesting effects from his cards.",
       ability: "He has two coils and starts the game with one charged. At the end of his turn, he charges one coil. At the start of his turn, if both coils are charged, he deals 1 damage to each opposing fighter adjacent to him and he moves them up to 1 space.",
       guides: [{
@@ -729,8 +729,8 @@
     {
       id: "38",
       name: "Dr. Jill Trent",
-      back: "https://i.imgur.com/kl5QnQp.png",
-      minis: ["https://i.imgur.com/4yH799l.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/dr-jill-trent-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/dr-jill-trent-mini.png"],
       desc: "Dr. Jill Trent and her side kick Daisy are melee fighters. She can choose between two different stances represented by her active gadget.",
       ability: "At the start of her turn, she activates one of her two gadgets. Whenever she attacks, the active gadget's effect resolves.<br/>- Gadget Hypnoray Blaster: DURING COMBAT: <i>If your card's printed value is lower than your opponent's, reveal the top card of your opponent's deck. Increase the value of your attack by the BOOST value of the revealed card.</i><br/>- Gadget Ultrabiotic Tonic: <i>AFTER COMBAT: If your card's printed value is higher than your opponent's, Jill Trent Recovers 1 health.</i>",
       guides: [{
@@ -743,8 +743,8 @@
     {
       id: "39",
       name: "The Golden Bat",
-      back: "https://i.imgur.com/VNUpu7s.png",
-      minis: ["https://i.imgur.com/5ZmKPCt.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/golden-bat-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/golden-bat-mini.png"],
       desc: "The Golden Bat is a melee fighter who can hit hard when attacking before doing any maneuver. He is also quite fast with 3 movement and has a couple of ways to move around with some of his cards effects.",
       ability: "If he hasn't taken a Maneuver action this turn, he adds +2 to the value of his attacks.",
       guides: [{
@@ -757,8 +757,8 @@
     {
       id: "40",
       name: "Annie Christmas",
-      back: "https://i.imgur.com/vbYI0iK.png",
-      minis: ["https://i.imgur.com/kQRm2OG.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/annie-christmas-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/annie-christmas-mini.png"],
       desc: "Annie Christmas is a melee fighter and her sidekick Charlie a ranged one. Annie Christmas can hit particularly hard when she has less life point than her opponent and with direct damages from card effects.",
       ability: "She adds +2 to the value of her attacks if she has less health than the defender.",
       guides: [{
@@ -771,8 +771,8 @@
     {
       id: "47",
       name: "Oda Nobunaga",
-      back: "https://i.imgur.com/oLaba4Z.png",
-      minis: ["https://i.imgur.com/YjVg0Vu.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/oda-nobunaga-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/oda-nobunaga-mini.png"],
       desc: "Oda Nobunaga is a melee fighter who has 2 melee sidekicks with 6 life points. Oda's ability is already giving a bonus to friendly fighters in his zone is already good by itself and it becomes extremely impactful when playing with other friendly heroes (2 vs 2 or collaborative).",
       ability: "Other friendly fighters in his zone add +1 to the value of their played combat cards.",
       set: ["Sun's Origin", "https://boardgamegeek.com/boardgame/383469/unmatched-suns-origin"],
@@ -782,8 +782,8 @@
     {
       id: "48",
       name: "Tomoe Gozen",
-      back: "https://i.imgur.com/vmLK2ni.png",
-      minis: ["https://i.imgur.com/OakTR0y.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/tomoe-gozen-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/tomoe-gozen-mini.png"],
       desc: "Tomoe Gozen is a ranged fighter who paradoxically tries to be adjacent to her opponents to get the most out of her cards. And if flee too far, they get shot by her attack of opportunity special ability.",
       ability: "When an opposing hero leaves her zone, deal 1 damage to that hero.",
       set: ["Sun's Origin", "https://boardgamegeek.com/boardgame/383469/unmatched-suns-origin"],
@@ -793,8 +793,8 @@
     {
       id: "49",
       name: "William Shakespeare",
-      back: "https://i.imgur.com/1btghdw.png",
-      minis: ["https://i.imgur.com/DwqEuP4.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/william-shakespeare-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/william-shakespeare-mini.png"],
       desc: "A ranged/mixed attacker who gains power by composing iambic‑pentameter—play cards sequentially to build ten‑syllable lines and trigger dramatic effects. His gimmick rewards careful planning and line‑completion, offering powerful combos once you hit that poetic sweet spot.",
       ability: "After you attack or defend, add your card to your line.<br/>When you line has 10 or more syllables, discard your line. If there are exactly 10 syllables, resolve the completion effect on the last card.",
       set: ["Slings and Arrows", "https://boardgamegeek.com/boardgame/415945/unmatched-slings-and-arrows"],
@@ -804,8 +804,8 @@
     {
       id: "50",
       name: "The Wayward Sisters",
-      back: "https://i.imgur.com/C2M0ZfA.png",
-      minis: ["https://i.imgur.com/1dmcIg1.png", "https://i.imgur.com/Uygl3lH.png", "https://i.imgur.com/61M5RzH.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/the-wayward-sisters-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/the-wayward-sisters-mini-a.png", "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/the-wayward-sisters-mini-b.png", "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/the-wayward-sisters-mini-c.png"],
       desc: "A trio of witches (no sidekicks) who mix cards into a shared cauldron instead of discarding them, triggering potent spells when the right ingredients accumulate. Their win condition relies on synergizing ingredient builds and timing big magic bursts for maximum board control.",
       ability: "Your cards go into your cauldron instead of your discard pile. After you attack, you may cast one spell that you have the ingredients for. If you do, discard all the cards in your cauldron.",
       set: ["Slings and Arrows", "https://boardgamegeek.com/boardgame/415945/unmatched-slings-and-arrows"],
@@ -815,8 +815,8 @@
     {
       id: "51",
       name: "Hamlet",
-      back: "https://i.imgur.com/CuG1Aw2.png",
-      minis: ["https://i.imgur.com/7rxmFeS.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/hamlet-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/hamlet-mini.png"],
       desc: "A melee-focused fighter supported by Rosencrantz & Guildenstern, who toggles between “To Be” (draw more cards when moving) and “Not To Be” (deal self‑damage to boost attack power). His core strategy is to balance life and cards—bait hits to empower stronger counters.",
       ability: "At the start of your turn, choose TO BE or NOT TO BE. If you choose NOT TO BE, deal 2 damage to one of your fighters.<br/>-TO BE: When you maneuver, draw 1 additional card.<br/>-NOT TO BE: Add +2 to the value of Hamlet's attacks.",
       set: ["Slings and Arrows", "https://boardgamegeek.com/boardgame/415945/unmatched-slings-and-arrows"],
@@ -826,8 +826,8 @@
     {
       id: "52",
       name: "Titania",
-      back: "https://i.imgur.com/VUEEeV8.png",
-      minis: ["https://i.imgur.com/b0SGNYO.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/titania-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/titania-mini.png"],
       desc: "Titania attacks as a ranged fighter and empowers her melee sidekick Oberon using Glamour cards that level up their strikes, but these resources are finite and must be spent judiciously. Best used by weaving fairies around the battlefield and timing Glamour plays to maximize each attack.",
       ability: "If you do not have a face-up glamour at the start of your turn, flip the top card of your glamour deck face-up. Its effect is ongoing while it remains face-up.",
       set: ["Slings and Arrows", "https://boardgamegeek.com/boardgame/415945/unmatched-slings-and-arrows"],
@@ -837,8 +837,8 @@
     {
       id: "53",
       name: "Geralt of Rivia",
-      back: "https://i.imgur.com/DueemMa.png",
-      minis: ["https://i.imgur.com/3pkDrcO.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/geralt-of-rivia-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/geralt-of-rivia-mini.png"],
       desc: "A melee-focused fighter supported by the ranged bard Dandelion sidekick, Geralt uses customizable gear (swords, armor, potions) to adapt to any matchup and gain situational advantages. His strength lies in tailor-making your deck during setup to counter your opponent’s strengths.",
       ability: "At the start of the game, choose your gear. Select a POTION, ARMOR, and SWORD, and shuffle 2 copies of each into your deck.",
       set: ["Steel and Silver", "https://boardgamegeek.com/boardgame/411860/unmatched-the-witcher-steel-and-silver"],
@@ -848,8 +848,8 @@
     {
       id: "54",
       name: "Ciri",
-      back: "https://i.imgur.com/PeQ8vFd.png",
-      minis: ["https://i.imgur.com/YGCa3cq.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ciri-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ciri-mini.png"],
       desc: "A fast-moving melee combatant with her unicorn sidekick Ihuarraquax, Ciri harnesses raw power from “Source” cards—each played into her discard pile —and once seven are there, her attacks become unblockable. Players should build momentum early while dancing around the board, then strike decisively before the deck runs out. ",
       ability: "Effects on Ciri's cards cannot be canceled.",
       set: ["Steel and Silver", "https://boardgamegeek.com/boardgame/411860/unmatched-the-witcher-steel-and-silver"],
@@ -859,8 +859,8 @@
     {
       id: "55",
       name: "Ancient Leshen",
-      back: "https://i.imgur.com/G94k9BJ.png",
-      minis: ["https://i.imgur.com/oZe5hLx.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ancient-leshen-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/ancient-leshen-mini.png"],
       desc: "A ranged monster with quick wolf sidekicks that harass opponents, the Leshen excels at positional play and board control, with abilities like “Heart of the Forest” that boost his presence and allow teleportation via crows. Maintain your wolves and leverage his ranged power to pressure foes across the battlefield.",
       ability: "Add +3 to the value of the Leshen's attacks if it already attacked this turn.",
       set: ["Steel and Silver", "https://boardgamegeek.com/boardgame/411860/unmatched-the-witcher-steel-and-silver"],
@@ -870,8 +870,8 @@
     {
       id: "56",
       name: "Eredin",
-      back: "https://i.imgur.com/m8uKYGB.png",
-      minis: ["https://i.imgur.com/mbnDLt2.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/eredin-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/eredin-mini.png"],
       desc: "A melee-centered villain commanding the Wild Hunt, Eredin gains strength from the riders he summons and sacrifices, turning battlefield losses into bruising blows. His strategy thrives on sustaining and bolstering sidekicks to amplify his own assault, while teleporting across the board to strike decisively.",
       ability: "While all of your Red Riders are defeated, Eredin is ENRAGED. <br/>If Eredin is ENRAGED, add +1 to the value of your combat cards, and your move value is 3.",
       set: ["Realms Fall","https://boardgamegeek.com/boardgame/411861/unmatched-the-witcher-realms-fall"],
@@ -881,8 +881,8 @@
     {
       id: "57",
       name: "Philippa",
-      back: "https://i.imgur.com/s5JIbFF.png",
-      minis: ["https://i.imgur.com/sOoqSw6.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/philippa-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/philippa-mini.png"],
       desc: "This powerful ranaged sorceress wields explosive magical control with mixed-range attacks, never running out of cards thanks to clever deck recursion. Her gimmick revolves around relentless tempo—dumping spells and looping them to overwhelm opponents with an endless avalanche.",
       ability: "At the end of your turn, you may draw until you have a hand of 4 cards.",
       set: ["Realms Fall","https://boardgamegeek.com/boardgame/411861/unmatched-the-witcher-realms-fall"],
@@ -892,8 +892,8 @@
     {
       id: "58",
       name: "Yennefer & Triss",
-      back: "https://i.imgur.com/AU20rgA.png",
-      minis: ["https://i.imgur.com/iyJgGnv.png", "https://i.imgur.com/LKxaAgb.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/yennefer-triss-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/yennefer-triss-mini-a.png", "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/yennefer-triss-mini-b.png"],
       desc: "A ranged duo who embody a new Unmatched twist: you choose who leads and who supports each game, unlocking distinct special abilities that suit your matchup. Whether it's Yennefer’s raw arcane control or Triss’s agile, fiery assaults, their strength lies in fluid role-swapping to maintain battlefield supremacy.",
       ability: "At the beginning of the game, choose Yennefer or Triss to be your hero. <br/>-Sorceress of Vengerberg<br/>IMMEDIATELY: If Yennefer is attacking, you may BOOST her attack. (This effect cannot be canceled.)<br/>-Merigold the Fearless<br/>After Triss plays a scheme, deal 2 damage to a fighter adjacent to Triss.",
       set: ["Realms Fall","https://boardgamegeek.com/boardgame/411861/unmatched-the-witcher-realms-fall"],
@@ -903,8 +903,8 @@
     {
       id: "59",
       name: "Muhammad Ali",
-      back: "https://i.imgur.com/Q42vFtf.png",
-      minis: ["https://i.imgur.com/79mFBwl.png"],
+      back: "https://file.garden/aVz14meKnkdh60_h/unmatched-roster/muhammad-ali-back.png",
+      minis: ["https://file.garden/aVz14meKnkdh60_h/unmatched-roster/muhammad-ali-mini.png"],
       desc: "Ali is a melee fighter able to switch between two different stances, one giving him some attack distance and the other stronger punches. He's often able to read opponent's mind by looking at his cards.",
       ability: "Ali has two stances: one allows him to attack 2 spaces away and empowers some of his cards, the other one gives him +2 to all of his attacks.",
       set: ["Lee vs Ali","https://boardgamegeek.com/boardgame/428308/unmatched-lee-vs-ali"],


### PR DESCRIPTION
Images that use imgur links show as "Content not viewable in your region" for some regions such as the UK. This replaces all imgur links with filegarden links.
<img width="336" height="478" alt="content-not-viewable-in-your-region" src="https://github.com/user-attachments/assets/d57749f5-a980-4024-9380-3a8616128e2f" />
